### PR TITLE
Add schematic converter backend

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,16 +1,36 @@
-"use strict";
+import express from 'express';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import multer from 'multer';
+import fs from 'fs/promises';
 
-const express = require("express");
-const path = require("path");
+import { installJava } from './scripts/install-java.js';
+import runSchemConvert from './converter/runSchemConvert.js';
 
-// Ensure Java is installed before starting the server
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const upload = multer({ dest: path.join(__dirname, 'uploads') });
+const convertedDir = path.join(__dirname, 'converted');
+
 async function prepareJava() {
-  const { installJava } = require("./scripts/install-java");
   const result = await installJava();
   if (!result.success) {
-    console.error("Java is required but could not be installed.");
+    console.error('Java is required but could not be installed.');
     process.exit(1);
   }
+}
+
+async function convertFiles(files, format) {
+  await fs.mkdir(convertedDir, { recursive: true });
+  const converted = [];
+  for (const file of files) {
+    const name = path.parse(file.originalname).name;
+    const outputFile = `${name}.${format}`;
+    const outputPath = path.join(convertedDir, outputFile);
+    await runSchemConvert(file.path, outputPath, format);
+    converted.push({ filename: outputFile });
+    await fs.unlink(file.path).catch(() => {});
+  }
+  return converted;
 }
 
 async function startServer() {
@@ -19,12 +39,26 @@ async function startServer() {
   const app = express();
   const PORT = process.env.PORT || 3000;
 
-  // Serve static files from the public directory
-  app.use(express.static(path.join(__dirname, "public")));
+  app.use(express.static(path.join(__dirname, 'public')));
+  app.use('/converted', express.static(convertedDir));
 
-  // Main route serving index.html
-  app.get("/", (req, res) => {
-    res.sendFile(path.join(__dirname, "public", "index.html"));
+  app.post('/convert', upload.array('files'), async (req, res) => {
+    const format = req.body.format;
+    if (!['litematic', 'schem', 'nbt', 'bp'].includes(format)) {
+      res.json({ success: false, error: 'Unsupported format' });
+      return;
+    }
+    try {
+      const converted = await convertFiles(req.files, format);
+      res.json({ success: true, converted });
+    } catch (err) {
+      console.error(err);
+      res.json({ success: false, error: err.message });
+    }
+  });
+
+  app.get('/', (req, res) => {
+    res.sendFile(path.join(__dirname, 'public', 'index.html'));
   });
 
   app.listen(PORT, () => {

--- a/converter/bpTolitematic.js
+++ b/converter/bpTolitematic.js
@@ -1,0 +1,5 @@
+import runSchemConvert from './runSchemConvert.js';
+
+export async function convertBpToLitematic(inputPath, outputPath) {
+  await runSchemConvert(inputPath, outputPath, 'litematic');
+}

--- a/converter/bpTonbt.js
+++ b/converter/bpTonbt.js
@@ -1,0 +1,5 @@
+import runSchemConvert from './runSchemConvert.js';
+
+export async function convertBpToNbt(inputPath, outputPath) {
+  await runSchemConvert(inputPath, outputPath, 'nbt');
+}

--- a/converter/bpToschem.js
+++ b/converter/bpToschem.js
@@ -1,0 +1,5 @@
+import runSchemConvert from './runSchemConvert.js';
+
+export async function convertBpToSchem(inputPath, outputPath) {
+  await runSchemConvert(inputPath, outputPath, 'schem');
+}

--- a/converter/index.js
+++ b/converter/index.js
@@ -1,0 +1,15 @@
+import runSchemConvert from './runSchemConvert.js';
+
+export { convertLitematicToSchem } from './litematicToschem.js';
+export { convertLitematicToNbt } from './litematicTonbt.js';
+export { convertLitematicToBp } from './litematicTobp.js';
+export { convertSchemToLitematic } from './schemTolitematic.js';
+export { convertSchemToNbt } from './schemTonbt.js';
+export { convertSchemToBp } from './schemTobp.js';
+export { convertNbtToLitematic } from './nbtTolitematic.js';
+export { convertNbtToSchem } from './nbtToschem.js';
+export { convertNbtToBp } from './nbtTobp.js';
+export { convertBpToLitematic } from './bpTolitematic.js';
+export { convertBpToSchem } from './bpToschem.js';
+export { convertBpToNbt } from './bpTonbt.js';
+export default runSchemConvert;

--- a/converter/litematicTobp.js
+++ b/converter/litematicTobp.js
@@ -1,0 +1,5 @@
+import runSchemConvert from './runSchemConvert.js';
+
+export async function convertLitematicToBp(inputPath, outputPath) {
+  await runSchemConvert(inputPath, outputPath, 'bp');
+}

--- a/converter/litematicTonbt.js
+++ b/converter/litematicTonbt.js
@@ -1,0 +1,5 @@
+import runSchemConvert from './runSchemConvert.js';
+
+export async function convertLitematicToNbt(inputPath, outputPath) {
+  await runSchemConvert(inputPath, outputPath, 'nbt');
+}

--- a/converter/litematicToschem.js
+++ b/converter/litematicToschem.js
@@ -1,0 +1,5 @@
+import runSchemConvert from './runSchemConvert.js';
+
+export async function convertLitematicToSchem(inputPath, outputPath) {
+  await runSchemConvert(inputPath, outputPath, 'schem');
+}

--- a/converter/nbtTobp.js
+++ b/converter/nbtTobp.js
@@ -1,0 +1,5 @@
+import runSchemConvert from './runSchemConvert.js';
+
+export async function convertNbtToBp(inputPath, outputPath) {
+  await runSchemConvert(inputPath, outputPath, 'bp');
+}

--- a/converter/nbtTolitematic.js
+++ b/converter/nbtTolitematic.js
@@ -1,0 +1,5 @@
+import runSchemConvert from './runSchemConvert.js';
+
+export async function convertNbtToLitematic(inputPath, outputPath) {
+  await runSchemConvert(inputPath, outputPath, 'litematic');
+}

--- a/converter/nbtToschem.js
+++ b/converter/nbtToschem.js
@@ -1,0 +1,5 @@
+import runSchemConvert from './runSchemConvert.js';
+
+export async function convertNbtToSchem(inputPath, outputPath) {
+  await runSchemConvert(inputPath, outputPath, 'schem');
+}

--- a/converter/runSchemConvert.js
+++ b/converter/runSchemConvert.js
@@ -1,0 +1,29 @@
+import { spawn } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const JAR_PATH = path.join(__dirname, '..', 'schemconvert.jar');
+
+/**
+ * Run SchemConvert CLI tool.
+ * @param {string} input - Path to input file.
+ * @param {string} output - Path to output file.
+ * @param {string} format - Output format extension (e.g. 'schem').
+ * @returns {Promise<void>} Resolves when conversion succeeds.
+ */
+export default function runSchemConvert(input, output, format) {
+  return new Promise((resolve, reject) => {
+    const args = ['-jar', JAR_PATH, '--input', input, '--output', output, '--format', format];
+    const proc = spawn('java', args);
+    let error = '';
+    proc.stderr.on('data', d => { error += d.toString(); });
+    proc.on('close', code => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(error || `SchemConvert exited with code ${code}`));
+      }
+    });
+  });
+}

--- a/converter/schemTobp.js
+++ b/converter/schemTobp.js
@@ -1,0 +1,5 @@
+import runSchemConvert from './runSchemConvert.js';
+
+export async function convertSchemToBp(inputPath, outputPath) {
+  await runSchemConvert(inputPath, outputPath, 'bp');
+}

--- a/converter/schemTolitematic.js
+++ b/converter/schemTolitematic.js
@@ -1,0 +1,5 @@
+import runSchemConvert from './runSchemConvert.js';
+
+export async function convertSchemToLitematic(inputPath, outputPath) {
+  await runSchemConvert(inputPath, outputPath, 'litematic');
+}

--- a/converter/schemTonbt.js
+++ b/converter/schemTonbt.js
@@ -1,0 +1,5 @@
+import runSchemConvert from './runSchemConvert.js';
+
+export async function convertSchemToNbt(inputPath, outputPath) {
+  await runSchemConvert(inputPath, outputPath, 'nbt');
+}

--- a/package.json
+++ b/package.json
@@ -1,12 +1,15 @@
 {
   "name": "MC-SchemConverter-NodeJS",
   "version": "1.0.0",
+  "type": "module",
   "scripts": {
     "install-java": "node scripts/install-java.js",
+    "generate-converters": "node scripts/generate-converters.js",
     "start": "node app.js"
   },
   "dependencies": {
     "dotenv": "^16.3.1",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "multer": "^1.4.5-lts.1"
   }
 }

--- a/scripts/generate-converters.js
+++ b/scripts/generate-converters.js
@@ -1,0 +1,35 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const targetDir = path.join(__dirname, '..', 'converter');
+
+const formats = ['litematic', 'schem', 'nbt', 'bp'];
+
+function cap(str) {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+async function generate() {
+  await fs.mkdir(targetDir, { recursive: true });
+  const exports = ["import runSchemConvert from './runSchemConvert.js';\n"];
+
+  for (const from of formats) {
+    for (const to of formats) {
+      if (from === to) continue;
+      const func = `convert${cap(from)}To${cap(to)}`;
+      const content = `import runSchemConvert from './runSchemConvert.js';\n\nexport async function ${func}(inputPath, outputPath) {\n  await runSchemConvert(inputPath, outputPath, '${to}');\n}\n`;
+      const fileName = `${from}To${to}.js`;
+      await fs.writeFile(path.join(targetDir, fileName), content);
+      exports.push(`export { ${func} } from './${fileName}';`);
+    }
+  }
+  await fs.writeFile(path.join(targetDir, 'index.js'), exports.join('\n'));
+  console.log('Converter modules generated in', targetDir);
+}
+
+generate().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/install-java.js
+++ b/scripts/install-java.js
@@ -1,8 +1,7 @@
-"use strict";
-
-const { exec } = require("child_process");
-const fs = require("fs");
-const path = require("path");
+import { exec } from "child_process";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
 
 class JavaInstaller {
   constructor() {
@@ -118,7 +117,7 @@ async function installJava() {
   return result;
 }
 
-if (require.main === module) {
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
   installJava().then(result => {
     if (result.success) {
       console.log("🎉 Java ready");
@@ -128,4 +127,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { installJava, JavaInstaller };
+export { installJava, JavaInstaller };


### PR DESCRIPTION
## Summary
- convert project to ES modules
- add `runSchemConvert` wrapper and generated converters
- implement new Express server with `/convert` endpoint
- provide script to generate converter modules

## Testing
- `npm install`
- `node app.js` *(server starts)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68794e40478c8330a993df7d84e63570