### PR TITLE
Load config from environment file

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,13 +1,16 @@
 import express from 'express';
+import cors from 'cors';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import multer from 'multer';
 import fs from 'fs/promises';
+import dotenv from 'dotenv';
 
 import { installJava } from './scripts/install-java.js';
 import runSchemConvert from './converter/runSchemConvert.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+dotenv.config({ path: path.join(__dirname, '.env') });
 const upload = multer({ dest: path.join(__dirname, 'uploads') });
 const convertedDir = path.join(__dirname, 'converted');
 
@@ -37,6 +40,9 @@ async function startServer() {
   await prepareJava();
 
   const app = express();
+  // Enable JSON body parsing and allow cross-origin requests
+  app.use(express.json());
+  app.use(cors());
   const PORT = process.env.PORT || 3000;
 
   app.use(express.static(path.join(__dirname, 'public')));

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "node app.js"
   },
   "dependencies": {
+    "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "multer": "^1.4.5-lts.1"

--- a/public/script.js
+++ b/public/script.js
@@ -88,7 +88,8 @@ document.getElementById("start-button").addEventListener("click", async () => {
   showProgress();
 
   try {
-    const response = await fetch("/convert", {
+    // Use absolute URL based on current origin to avoid cross-origin issues
+    const response = await fetch(`${window.location.origin}/convert`, {
       method: "POST",
       body: formData
     });

--- a/scripts/install-java.js
+++ b/scripts/install-java.js
@@ -2,12 +2,17 @@ import { exec } from "child_process";
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
+import dotenv from "dotenv";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+dotenv.config({ path: path.resolve(__dirname, "..", ".env") });
 
 class JavaInstaller {
   constructor() {
     this.javaDir = process.env.JAVA_DIR || "/home/container/java";
     this.javaVersion = process.env.JAVA_VERSION || "21";
-    this.baseUrl = "https://download.oracle.com/java";
+    // Allow overriding the base download URL via environment
+    this.baseUrl = process.env.JAVA_BASE_URL || "https://download.oracle.com/java";
     this.downloadUrl = `${this.baseUrl}/${this.javaVersion}/latest/jdk-${this.javaVersion}_linux-x64_bin.tar.gz`;
     this.jdkDirPattern = `jdk-${this.javaVersion}`;
   }


### PR DESCRIPTION
## Summary
- load `.env` before starting the Express server
- load `.env` in Java installer so JAVA_DIR and JAVA_VERSION variables apply
- use absolute URL for API calls from `script.js`
- add CORS and JSON handling middleware

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687958f48d4c8330963a27e99eb53ef2