### PR TITLE
Fix Java path usage during schematics conversion

### DIFF
--- a/converter/runSchemConvert.js
+++ b/converter/runSchemConvert.js
@@ -4,7 +4,10 @@ import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const JAR_PATH = path.join(__dirname, '..', 'schemconvert.jar');
-const JAVA_CMD = process.env.JAVA_PATH || 'java';
+
+function getJavaCmd() {
+  return process.env.JAVA_PATH || 'java';
+}
 
 /**
  * Run SchemConvert CLI tool.
@@ -16,7 +19,7 @@ const JAVA_CMD = process.env.JAVA_PATH || 'java';
 export default function runSchemConvert(input, output, format) {
   return new Promise((resolve, reject) => {
     const args = ['-jar', JAR_PATH, '--input', input, '--output', output, '--format', format];
-    const proc = spawn(JAVA_CMD, args);
+    const proc = spawn(getJavaCmd(), args);
     let error = '';
     proc.on('error', err => {
       reject(err);

--- a/public/index.html
+++ b/public/index.html
@@ -44,7 +44,7 @@
 
       <div class="main-content">
         <!-- File Upload Card -->
-        <div class="card" id="upload-card">
+        <div class="card fade-in" id="upload-card">
           <div class="card-title">Choose Files</div>
           <div class="card-description">Drag & drop or click to select your schematic files</div>
           <div class="file-upload" id="file-upload">
@@ -57,7 +57,7 @@
         </div>
 
         <!-- Format Selection Card -->
-        <div class="card" id="format-card">
+        <div class="card fade-in" id="format-card">
           <div class="card-title">Select Output Format</div>
           <div class="card-description">Choose the format you want to convert to</div>
           <div class="format-options">

--- a/public/script.js
+++ b/public/script.js
@@ -111,12 +111,24 @@ function showProgress() {
   document.getElementById("progress-section").style.display = "block";
   document.getElementById("main-page").classList.add("disabled");
   document.getElementById("progress-fill").style.width = "100%";
+
+  document.getElementById("upload-icon").classList.add("complete");
+  const convertIcon = document.getElementById("convert-icon");
+  convertIcon.classList.remove("inactive");
+  convertIcon.classList.add("processing");
 }
 
 // Zobrazenie výsledkov
 function showDownloadPage(convertedFiles) {
   document.getElementById("main-page").style.display = "none";
   document.getElementById("download-page").style.display = "block";
+
+  const convertIcon = document.getElementById("convert-icon");
+  convertIcon.classList.remove("processing");
+  convertIcon.classList.add("complete");
+  const downloadIcon = document.getElementById("download-icon");
+  downloadIcon.classList.remove("inactive");
+  downloadIcon.classList.add("complete");
 
   const container = document.getElementById("download-files");
   container.innerHTML = "";

--- a/public/styles.css
+++ b/public/styles.css
@@ -6,6 +6,19 @@
   box-sizing: border-box;
 }
 
+.fade-in {
+  opacity: 0;
+  transform: translateY(20px);
+  animation: fadeInUp 0.6s forwards;
+}
+
+@keyframes fadeInUp {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 body {
   font-family: 'Inter', sans-serif;
   background: linear-gradient(135deg, #e5e7eb 0%, #f3f4f6 50%, #e5e7eb 100%);
@@ -121,8 +134,17 @@ body {
   width: 60px;
   height: 2px;
   background: #d1d5db;
-  position: relative;
-  top: -40px;
+  align-self: center;
+}
+
+.step-icon.complete {
+  animation: pop 0.5s ease;
+}
+
+@keyframes pop {
+  0% { transform: scale(1); }
+  50% { transform: scale(1.2); }
+  100% { transform: scale(1); }
 }
 
 @keyframes pulse {


### PR DESCRIPTION
## Summary
- load JAVA_PATH when conversion runs instead of module import time
- add fade-in animations to upload and format cards
- vertically center step connectors and animate step progress icons

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687fda65ebe883309471ff3b7944a566