### PR TITLE
Improve backend validation and format handling

### DIFF
--- a/app.js
+++ b/app.js
@@ -24,6 +24,8 @@ const storage = multer.diskStorage({
 const upload = multer({ storage });
 const convertedDir = path.join(__dirname, 'converted');
 
+const SUPPORTED_FORMATS = new Set(['litematic', 'schem', 'nbt', 'bp']);
+
 async function prepareJava() {
   const result = await installJava();
   if (!result.success) {
@@ -35,19 +37,18 @@ async function prepareJava() {
 
 async function convertFiles(files, format) {
   await fs.mkdir(convertedDir, { recursive: true });
-  const converted = [];
-  for (const file of files) {
+
+  const tasks = files.map(async (file) => {
     const base = path.parse(file.originalname).name;
     const outputFile = `${base}.${format}`;
     const outputPath = path.join(convertedDir, outputFile);
 
     await runSchemConvert(file.path, outputPath, format);
-    converted.push({ filename: outputFile });
-
-    // Remove uploaded file after conversion
     await fs.unlink(file.path).catch(() => {});
-  }
-  return converted;
+    return { filename: outputFile };
+  });
+
+  return Promise.all(tasks);
 }
 
 async function startServer() {
@@ -62,11 +63,22 @@ async function startServer() {
   app.use(express.static(path.join(__dirname, 'public')));
   app.use('/converted', express.static(convertedDir));
 
+  app.get('/formats', (_req, res) => {
+    res.json({ formats: Array.from(SUPPORTED_FORMATS) });
+  });
+
   app.post('/convert', upload.array('files'), async (req, res) => {
     const format = req.body.format;
-    if (!['litematic', 'schem', 'nbt', 'bp'].includes(format)) {
+    if (!SUPPORTED_FORMATS.has(format)) {
       res.json({ success: false, error: 'Unsupported format' });
       return;
+    }
+    for (const f of req.files) {
+      const ext = path.extname(f.originalname).slice(1).toLowerCase();
+      if (!SUPPORTED_FORMATS.has(ext)) {
+        res.json({ success: false, error: `File type .${ext} is not supported` });
+        return;
+      }
     }
     try {
       const converted = await convertFiles(req.files, format);

--- a/public/index.html
+++ b/public/index.html
@@ -22,7 +22,7 @@
     <div class="main-page" id="main-page">
       <div class="header">
         <h1 class="title">SCHEMATIC CONVERTER</h1>
-        <p class="subtitle">Convert between Minecraft schematic formats</p>
+        <p class="subtitle">Convert between Minecraft formats</p>
       </div>
 
       <div class="process-steps">
@@ -46,12 +46,12 @@
         <!-- File Upload Card -->
         <div class="card fade-in" id="upload-card">
           <div class="card-title">Choose Files</div>
-          <div class="card-description">Drag & drop or click to select your schematic files</div>
+          <div class="card-description">Drag & drop or click to select your files</div>
           <div class="file-upload" id="file-upload">
             <div class="file-upload-icon">📁</div>
             <div class="file-upload-text">Select Files</div>
-            <div class="file-upload-subtext">Supported: .litematic, .schematic, .schem, .nbt</div>
-            <input type="file" class="file-input" id="file-input" multiple accept=".litematic,.schematic,.schem,.nbt">
+            <div class="file-upload-subtext">Supported: .litematic, .schem, .nbt, .bp</div>
+            <input type="file" class="file-input" id="file-input" multiple accept=".litematic,.schem,.nbt,.bp">
           </div>
           <div class="selected-files" id="selected-files"></div>
         </div>
@@ -62,20 +62,24 @@
           <div class="card-description">Choose the format you want to convert to</div>
           <div class="format-options">
             <div class="format-option" data-format="litematic">
+              <img src="logos/litematic.png" alt="Litematica logo" class="format-logo" />
               <div class="format-name">Litematica</div>
               <div class="format-ext">.litematic</div>
             </div>
-            <div class="format-option" data-format="schematic">
-              <div class="format-name">WorldEdit</div>
-              <div class="format-ext">.schematic</div>
-            </div>
             <div class="format-option" data-format="schem">
-              <div class="format-name">Sponge</div>
+              <img src="logos/schem.png" alt="WorldEdit logo" class="format-logo" />
+              <div class="format-name">WorldEdit</div>
               <div class="format-ext">.schem</div>
             </div>
             <div class="format-option" data-format="nbt">
-              <div class="format-name">Structure</div>
+              <img src="logos/nbt.png" alt="Vanilla Structure logo" class="format-logo" />
+              <div class="format-name">Vanilla Structure</div>
               <div class="format-ext">.nbt</div>
+            </div>
+            <div class="format-option" data-format="bp">
+              <img src="logos/bp.png" alt="Axiom Blueprint logo" class="format-logo" />
+              <div class="format-name">Axiom Blueprint</div>
+              <div class="format-ext">.bp</div>
             </div>
           </div>
         </div>

--- a/public/script.js
+++ b/public/script.js
@@ -1,7 +1,22 @@
 let selectedFiles = [];
 let selectedFormat = null;
+let supportedFormats = [];
 
-// Výber formátu
+async function loadFormats() {
+  try {
+    const res = await fetch('formats');
+    const data = await res.json();
+    supportedFormats = data.formats;
+    const accept = supportedFormats.map(f => '.' + f).join(',');
+    fileInput.setAttribute('accept', accept);
+    document.querySelector('.file-upload-subtext').textContent =
+      'Supported: ' + accept;
+  } catch (e) {
+    console.error('Failed to load formats', e);
+  }
+}
+
+// Format selection
 document.querySelectorAll(".format-option").forEach(option => {
   option.addEventListener("click", () => {
     document.querySelectorAll(".format-option").forEach(o => o.classList.remove("selected"));
@@ -11,15 +26,17 @@ document.querySelectorAll(".format-option").forEach(option => {
   });
 });
 
-// Výber súborov
+// File selection
 const fileInput = document.getElementById("file-input");
 const fileUpload = document.getElementById("file-upload");
 const selectedFilesContainer = document.getElementById("selected-files");
 
-// Po kliknutí na upload zónu otvorí dialóg pre výber súborov
+loadFormats();
+
+// Open file dialog when the upload area is clicked
 fileUpload.addEventListener("click", () => fileInput.click());
 
-// Umožní drag & drop nahrávanie súborov
+// Allow drag & drop file uploads
 fileUpload.addEventListener("dragover", (e) => {
   e.preventDefault();
   fileUpload.classList.add("dragover");
@@ -38,7 +55,7 @@ fileUpload.addEventListener("drop", (e) => {
   checkReadyState();
 });
 
-// Reaguje na zmenu inputu a prida nové súbory k existujúcim
+// Add newly selected files to the list when the input changes
 fileInput.addEventListener("change", (e) => {
   selectedFiles = selectedFiles.concat(Array.from(e.target.files));
   displaySelectedFiles();
@@ -74,10 +91,10 @@ function checkReadyState() {
   }
 }
 
-// Spustenie konverzie
+// Start conversion
 document.getElementById("start-button").addEventListener("click", async () => {
-  if (!["litematic", "schem", "schematic", "nbt"].includes(selectedFormat)) {
-    alert("Zvolený formát nie je podporovaný.");
+  if (!supportedFormats.includes(selectedFormat)) {
+    alert("The selected format is not supported.");
     return;
   }
 
@@ -98,15 +115,15 @@ document.getElementById("start-button").addEventListener("click", async () => {
     if (data.success) {
       showDownloadPage(data.converted);
     } else {
-      alert("Chyba pri konverzii: " + data.error);
+      alert("Conversion failed: " + data.error);
     }
   } catch (err) {
     console.error(err);
-    alert("Došlo k chybe pri odosielaní súborov.");
+    alert("There was an error uploading your files.");
   }
 });
 
-// Zobrazenie progres baru
+// Display progress bar
 function showProgress() {
   document.getElementById("progress-section").style.display = "block";
   document.getElementById("main-page").classList.add("disabled");
@@ -118,7 +135,7 @@ function showProgress() {
   convertIcon.classList.add("processing");
 }
 
-// Zobrazenie výsledkov
+// Show conversion results
 function showDownloadPage(convertedFiles) {
   document.getElementById("main-page").style.display = "none";
   document.getElementById("download-page").style.display = "block";
@@ -146,7 +163,7 @@ function showDownloadPage(convertedFiles) {
   });
 }
 
-// Tlačidlo Nová konverzia
+// "New Conversion" button
 document.getElementById("new-conversion-button").addEventListener("click", () => {
   location.reload();
 });

--- a/public/styles.css
+++ b/public/styles.css
@@ -272,6 +272,13 @@ body {
   transition: all 0.3s ease;
 }
 
+.format-logo {
+  width: 48px;
+  height: 48px;
+  margin-bottom: 8px;
+  object-fit: contain;
+}
+
 .format-option:hover,
 .format-option.selected {
   border-color: #22c55e;


### PR DESCRIPTION
## Summary
- check supported formats server-side and expose `/formats` API
- convert files concurrently for better performance
- dynamically load supported formats in the client script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688001f0890883309651d2798bf4b808