### PR TITLE
Add error page and improve server error handling

### DIFF
--- a/app.js
+++ b/app.js
@@ -26,6 +26,38 @@ const convertedDir = path.join(__dirname, 'converted');
 
 const SUPPORTED_FORMATS = new Set(['litematic', 'schem', 'nbt', 'bp']);
 
+/**
+ * Remove uploaded files to keep temporary storage clean.
+ * This runs even if some files are already deleted.
+ * @param {Array<{path: string}>} files
+ */
+async function cleanupUploads(files) {
+  await Promise.all(files.map(f => fs.unlink(f.path).catch(() => {})));
+}
+
+/**
+ * Map low-level errors to user-friendly explanations.
+ * @param {Error & {code?: string}} err
+ * @returns {{code: string, message: string}}
+ */
+function mapError(err) {
+  const msg = err.message || '';
+  switch (true) {
+    case err.code === 'ENOENT':
+      return {
+        code: 'JAVA_NOT_FOUND',
+        message: 'Java runtime could not be executed. Ensure Java is installed on the server.'
+      };
+    case /heap space/i.test(msg) || /outofmemory/i.test(msg):
+      return {
+        code: 'JAVA_HEAP_SPACE',
+        message: 'The converter ran out of memory (Java heap space). Try converting a smaller file or increasing server memory.'
+      };
+    default:
+      return { code: 'UNKNOWN', message: msg || 'Unknown error occurred during conversion.' };
+  }
+}
+
 async function prepareJava() {
   const result = await installJava();
   if (!result.success) {
@@ -70,13 +102,15 @@ async function startServer() {
   app.post('/convert', upload.array('files'), async (req, res) => {
     const format = req.body.format;
     if (!SUPPORTED_FORMATS.has(format)) {
-      res.json({ success: false, error: 'Unsupported format' });
+      await cleanupUploads(req.files);
+      res.json({ success: false, error: { code: 'UNSUPPORTED_FORMAT', message: 'The selected output format is not supported.' } });
       return;
     }
     for (const f of req.files) {
       const ext = path.extname(f.originalname).slice(1).toLowerCase();
       if (!SUPPORTED_FORMATS.has(ext)) {
-        res.json({ success: false, error: `File type .${ext} is not supported` });
+        await cleanupUploads(req.files);
+        res.json({ success: false, error: { code: 'FILE_TYPE_NOT_SUPPORTED', message: `File type .${ext} is not supported.` } });
         return;
       }
     }
@@ -85,7 +119,8 @@ async function startServer() {
       res.json({ success: true, converted });
     } catch (err) {
       console.error(err);
-      res.json({ success: false, error: err.message });
+      await cleanupUploads(req.files);
+      res.json({ success: false, error: mapError(err) });
     }
   });
 

--- a/public/index.html
+++ b/public/index.html
@@ -114,6 +114,20 @@
         </div>
       </div>
     </div>
+
+    <!-- Error Page -->
+    <div class="error-page" id="error-page">
+      <div class="header">
+        <h1 class="title">CONVERSION FAILED</h1>
+        <p class="subtitle">An error occurred during conversion</p>
+      </div>
+      <div class="error-container">
+        <div class="error-icon">❌</div>
+        <div class="error-title" id="error-title">ERROR</div>
+        <div class="error-description" id="error-description"></div>
+        <button class="new-conversion-button" id="error-new-conversion-button">Try Again</button>
+      </div>
+    </div>
   </div>
 
   <footer class="footer">

--- a/public/script.js
+++ b/public/script.js
@@ -2,6 +2,10 @@ let selectedFiles = [];
 let selectedFormat = null;
 let supportedFormats = [];
 
+// Progress bar state
+let progressInterval = null;
+let progressValue = 0;
+
 async function loadFormats() {
   try {
     const res = await fetch('formats');
@@ -115,19 +119,33 @@ document.getElementById("start-button").addEventListener("click", async () => {
     if (data.success) {
       showDownloadPage(data.converted);
     } else {
-      alert("Conversion failed: " + data.error);
+      showErrorPage(data.error);
     }
   } catch (err) {
     console.error(err);
-    alert("There was an error uploading your files.");
+    showErrorPage({ code: 'NETWORK', message: 'There was an error uploading your files.' });
   }
 });
 
 // Display progress bar
 function showProgress() {
-  document.getElementById("progress-section").style.display = "block";
+  const progressSection = document.getElementById("progress-section");
+  const progressFill = document.getElementById("progress-fill");
+  const progressText = document.getElementById("progress-text");
+
+  progressSection.style.display = "block";
   document.getElementById("main-page").classList.add("disabled");
-  document.getElementById("progress-fill").style.width = "100%";
+
+  // Reset and start an incremental animation until the server responds
+  progressValue = 0;
+  progressFill.style.width = "0%";
+  progressText.textContent = "Converting files... 0%";
+
+  progressInterval = setInterval(() => {
+    progressValue = Math.min(progressValue + Math.random() * 10, 90);
+    progressFill.style.width = `${progressValue}%`;
+    progressText.textContent = `Converting files... ${Math.floor(progressValue)}%`;
+  }, 500);
 
   document.getElementById("upload-icon").classList.add("complete");
   const convertIcon = document.getElementById("convert-icon");
@@ -137,6 +155,13 @@ function showProgress() {
 
 // Show conversion results
 function showDownloadPage(convertedFiles) {
+  // Finalize progress bar before showing results
+  clearInterval(progressInterval);
+  const progressFill = document.getElementById("progress-fill");
+  const progressText = document.getElementById("progress-text");
+  progressFill.style.width = "100%";
+  progressText.textContent = "Converting files... 100%";
+
   document.getElementById("main-page").style.display = "none";
   document.getElementById("download-page").style.display = "block";
 
@@ -163,7 +188,34 @@ function showDownloadPage(convertedFiles) {
   });
 }
 
+// Show error page with explanation
+function showErrorPage(error) {
+  // Finalize progress bar before displaying the error page
+  clearInterval(progressInterval);
+  const progressFill = document.getElementById("progress-fill");
+  const progressText = document.getElementById("progress-text");
+  progressFill.style.width = "100%";
+  progressText.textContent = "Converting files... 100%";
+
+  document.getElementById("main-page").style.display = "none";
+  document.getElementById("progress-section").style.display = "none";
+  document.getElementById("error-page").style.display = "block";
+
+  const convertIcon = document.getElementById("convert-icon");
+  convertIcon.classList.remove("processing");
+  convertIcon.classList.add("error");
+
+  document.getElementById("error-title").textContent =
+    (error && error.code) ? error.code.replace(/_/g, ' ') : "ERROR";
+  document.getElementById("error-description").textContent =
+    (error && error.message) ? error.message : "An unknown error occurred during conversion.";
+}
+
 // "New Conversion" button
 document.getElementById("new-conversion-button").addEventListener("click", () => {
+  location.reload();
+});
+
+document.getElementById("error-new-conversion-button").addEventListener("click", () => {
   location.reload();
 });

--- a/public/styles.css
+++ b/public/styles.css
@@ -121,6 +121,7 @@ body {
 
 .step-icon.inactive { background: #9ca3af; }
 .step-icon.processing { background: #3b82f6; animation: pulse 1.5s infinite; }
+.step-icon.error { background: #ef4444; }
 
 .step-label {
   font-size: 12px;
@@ -430,6 +431,45 @@ body {
 
 .download-button:hover {
   background: #16a34a;
+}
+
+.error-page {
+  display: none;
+  text-align: center;
+  padding: 40px 0;
+}
+
+.error-page.active {
+  display: block;
+}
+
+.error-container {
+  background: #fef2f2;
+  border: 2px solid #ef4444;
+  border-radius: 12px;
+  padding: 40px;
+  margin: 40px auto;
+  max-width: 600px;
+}
+
+.error-icon {
+  font-size: 64px;
+  color: #ef4444;
+  margin-bottom: 20px;
+}
+
+.error-title {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 20px;
+  color: #111827;
+  margin-bottom: 16px;
+  letter-spacing: 1px;
+}
+
+.error-description {
+  font-size: 16px;
+  color: #6b7280;
+  margin-bottom: 30px;
 }
 
 .download-all-button {


### PR DESCRIPTION
## Summary
- handle conversion failures by cleaning up uploads and returning informative error codes
- add client-side error page that explains issues and allows retry
- style error display and step icons for failure states
- replace conditional error mapping with a switch and animate progress bar until conversion completes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68991e9260c483309fb034bd58d9ca50